### PR TITLE
Always fire update callbacks even when sensor value is unchanged

### DIFF
--- a/aioecowitt/sensor.py
+++ b/aioecowitt/sensor.py
@@ -37,8 +37,6 @@ class EcoWittSensor:
         self.last_update_m = last_update_m
 
         # Set the value
-        if self.value == value:
-            return
         self.value = value
 
         # notify listeners


### PR DESCRIPTION
Currently, EcoWittSensor update callbacks only fire when the sensor value changes. This means HA entities don't call async_write_ha_state() for sensors with stable values (e.g., rain rate = 0.0 when not raining), causing `last_reported` to go stale even though the gateway is pushing data every 60 seconds.

This makes it impossible to reliably detect whether a sensor has stopped communicating, which is the entire purpose of `last_reported` (introduced in HA 2024.3).

Fix: Remove the early-return guard in EcoWittSensor.value setter so callbacks always fire when data is received from the gateway, regardless of whether the value changed. HA already has logic in place to not create duplicate records (but only update `last_reported`) if the data hasn't changed.