### PR TITLE
Add WN20 (rain gauge) battery sensor

### DIFF
--- a/aioecowitt/sensor.py
+++ b/aioecowitt/sensor.py
@@ -348,6 +348,7 @@ SENSOR_MAP: dict[str, EcoWittMapping] = {
     "wh85batt": EcoWittMapping("WH85 Battery", EcoWittSensorTypes.BATTERY_VOLTAGE),
     "wh90batt": EcoWittMapping("WH90 Battery", EcoWittSensorTypes.BATTERY_VOLTAGE),
     "bgtbatt": EcoWittMapping("WN38 Battery", EcoWittSensorTypes.BATTERY_VOLTAGE),
+    "wn20batt": EcoWittMapping("WN20 Battery", EcoWittSensorTypes.BATTERY_VOLTAGE),
     "soilbatt1": EcoWittMapping("Soil Battery 1", EcoWittSensorTypes.BATTERY_VOLTAGE),
     "soilbatt2": EcoWittMapping("Soil Battery 2", EcoWittSensorTypes.BATTERY_VOLTAGE),
     "soilbatt3": EcoWittMapping("Soil Battery 3", EcoWittSensorTypes.BATTERY_VOLTAGE),

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -42,6 +42,7 @@ def test_update_listener() -> None:
     [
         ("heap", GW2000A_V3_DATA["heap"], GW2000A_V3_DATA),
         ("vpd", 0.091, {**GW2000A_V3_DATA, "vpd": "0.091"}),
+        ("wn20batt", 2.68, {**GW2000A_V3_DATA, "wn20batt": "2.68"}),
     ],
 )
 async def test_sensor(


### PR DESCRIPTION
## What

Adds a `SENSOR_MAP` entry for `wn20batt` — the battery of the **Ecowitt WN20 Wireless Rain Gauge Mini** (powered by 2× AAA).

## Why

With the Home Assistant `ecowitt` integration (a GW1200A gateway here), `aioecowitt` logs this on every gateway update / HA restart:

```
Unhandled sensor type wn20batt value 2.68
```

`wn20batt` isn't in `SENSOR_MAP`, so the WN20's battery is never exposed and the warning is emitted repeatedly. The value is a voltage (e.g. `2.68`), exactly like the other `*batt` voltage sensors (`wh40batt`, `wh80batt`, `wh90batt`, `bgtbatt`, …), so it's mapped as `BATTERY_VOLTAGE`.

## Changes

- `aioecowitt/sensor.py` — `"wn20batt": EcoWittMapping("WN20 Battery", EcoWittSensorTypes.BATTERY_VOLTAGE)` (next to `bgtbatt`/WN38).
- `tests/test_sensor.py` — parametrized case asserting the `wn20batt` sensor is created with value `2.68`.

## Testing

`pytest` → 12 passed; `ruff check .` → all checks passed (Python 3.13).
